### PR TITLE
chore: 勉強用フォルダの追加

### DIFF
--- a/Assets/Scenes/Learning.meta
+++ b/Assets/Scenes/Learning.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c01db807fe443d448be0eee510d8efcb
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/Learning/Ochi.meta
+++ b/Assets/Scenes/Learning/Ochi.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: fad7546e8f24360439e13de4d1bd9371
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/Learning/Yoshida.meta
+++ b/Assets/Scenes/Learning/Yoshida.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: cd8e8628bcefc684c9ec19eab28cb8a6
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## 🧠 Notion
<!-- 対応するタスクやNotionのリンクを貼ってください -->
[オブジェクト指向勉強](https://www.notion.so/tokushima-igc/1d7818401853806f8c44e6c037ebd89d?pvs=4)


## 📚 Description
<!-- 変更内容を簡潔に記述してください（例: 機能追加、バグ修正、リファクタリングなど） -->
- 勉強用フォルダの生成


## 📸 Screenshot / 動作確認結果（必要があれば）
<!-- UI変更がある場合、スクショや画面キャプチャを貼るとレビューが楽になります -->
- 特になし

## 🚧 Not included in this PR
<!-- このPRには含まれていないが、関連しているものや次に対応する予定のもの -->
- 特になし

## 📝 Reviewer checklist & Notes
<!-- 補足情報・レビュワーへの伝達事項・悩んでいることなど -->
- 特になし
<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- 新機能：`Learning`シーンに新しいフォルダアセットを追加しました。これにより、ユーザーは`Ochi`と`Yoshida`の新しい学習リソースにアクセスできるようになります。これらの変更は内部的なものであり、エンドユーザーに直接的な影響はありませんが、新しい学習コンテンツの組織と管理を改善します。
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->