### PR TITLE
イベントのEventStatusの管理にR3を導入する

### DIFF
--- a/Assets/Scenes/DeveloppingScenes/BaseEvent.unity
+++ b/Assets/Scenes/DeveloppingScenes/BaseEvent.unity
@@ -119,6 +119,177 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1001 &80645585
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 5670342439500447563, guid: 10e9f26f4c9d0e6458a827320fedfd55, type: 3}
+      propertyPath: m_Name
+      value: EssentialObject
+      objectReference: {fileID: 0}
+    - target: {fileID: 7241027210948899250, guid: 10e9f26f4c9d0e6458a827320fedfd55, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7241027210948899250, guid: 10e9f26f4c9d0e6458a827320fedfd55, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7241027210948899250, guid: 10e9f26f4c9d0e6458a827320fedfd55, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7241027210948899250, guid: 10e9f26f4c9d0e6458a827320fedfd55, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7241027210948899250, guid: 10e9f26f4c9d0e6458a827320fedfd55, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7241027210948899250, guid: 10e9f26f4c9d0e6458a827320fedfd55, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7241027210948899250, guid: 10e9f26f4c9d0e6458a827320fedfd55, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7241027210948899250, guid: 10e9f26f4c9d0e6458a827320fedfd55, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7241027210948899250, guid: 10e9f26f4c9d0e6458a827320fedfd55, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7241027210948899250, guid: 10e9f26f4c9d0e6458a827320fedfd55, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 10e9f26f4c9d0e6458a827320fedfd55, type: 3}
+--- !u!1001 &289236845
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 3808477812684150828, guid: 7c82e04b7e693f3449e67247d4c7c0a9, type: 3}
+      propertyPath: m_Name
+      value: Player
+      objectReference: {fileID: 0}
+    - target: {fileID: 4829411122311754825, guid: 7c82e04b7e693f3449e67247d4c7c0a9, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -3.59
+      objectReference: {fileID: 0}
+    - target: {fileID: 4829411122311754825, guid: 7c82e04b7e693f3449e67247d4c7c0a9, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.6456671
+      objectReference: {fileID: 0}
+    - target: {fileID: 4829411122311754825, guid: 7c82e04b7e693f3449e67247d4c7c0a9, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4829411122311754825, guid: 7c82e04b7e693f3449e67247d4c7c0a9, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4829411122311754825, guid: 7c82e04b7e693f3449e67247d4c7c0a9, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4829411122311754825, guid: 7c82e04b7e693f3449e67247d4c7c0a9, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4829411122311754825, guid: 7c82e04b7e693f3449e67247d4c7c0a9, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4829411122311754825, guid: 7c82e04b7e693f3449e67247d4c7c0a9, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4829411122311754825, guid: 7c82e04b7e693f3449e67247d4c7c0a9, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4829411122311754825, guid: 7c82e04b7e693f3449e67247d4c7c0a9, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7c82e04b7e693f3449e67247d4c7c0a9, type: 3}
+--- !u!1001 &328043221
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 3718633801902478523, guid: 7abbfa9e433be7c43985f64e44588983, type: 3}
+      propertyPath: m_Name
+      value: TextEvent
+      objectReference: {fileID: 0}
+    - target: {fileID: 7262873857064080201, guid: 7abbfa9e433be7c43985f64e44588983, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -3.07
+      objectReference: {fileID: 0}
+    - target: {fileID: 7262873857064080201, guid: 7abbfa9e433be7c43985f64e44588983, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.07
+      objectReference: {fileID: 0}
+    - target: {fileID: 7262873857064080201, guid: 7abbfa9e433be7c43985f64e44588983, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7262873857064080201, guid: 7abbfa9e433be7c43985f64e44588983, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7262873857064080201, guid: 7abbfa9e433be7c43985f64e44588983, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7262873857064080201, guid: 7abbfa9e433be7c43985f64e44588983, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7262873857064080201, guid: 7abbfa9e433be7c43985f64e44588983, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7262873857064080201, guid: 7abbfa9e433be7c43985f64e44588983, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7262873857064080201, guid: 7abbfa9e433be7c43985f64e44588983, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7262873857064080201, guid: 7abbfa9e433be7c43985f64e44588983, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7abbfa9e433be7c43985f64e44588983, type: 3}
 --- !u!1 &567392423
 GameObject:
   m_ObjectHideFlags: 0
@@ -150,6 +321,9 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _event: 1
   _isTriggeredOnce: 0
+  _eventId: 
+  _storyLayer: 0
+  _isUpStoryLayer: 0
 --- !u!4 &567392425
 Transform:
   m_ObjectHideFlags: 0
@@ -308,3 +482,6 @@ SceneRoots:
   m_Roots:
   - {fileID: 2081186185}
   - {fileID: 567392425}
+  - {fileID: 80645585}
+  - {fileID: 289236845}
+  - {fileID: 328043221}

--- a/Assets/Scenes/GameScenes/First/1/Dream/School/2F/First_1_dream_class201.unity
+++ b/Assets/Scenes/GameScenes/First/1/Dream/School/2F/First_1_dream_class201.unity
@@ -2549,7 +2549,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 2265354364521353274, guid: 7abbfa9e433be7c43985f64e44588983, type: 3}
       propertyPath: _eventId
-      value: 9a61b67c-7461-454e-bfd5-836c2dff634e
+      value: fc069ed8-ae08-4038-b465-74975be82f1d
       objectReference: {fileID: 0}
     - target: {fileID: 2265354364521353274, guid: 7abbfa9e433be7c43985f64e44588983, type: 3}
       propertyPath: _isTriggeredOnce

--- a/Assets/Scenes/GameScenes/First/1/Real/First_1_real_house.unity
+++ b/Assets/Scenes/GameScenes/First/1/Real/First_1_real_house.unity
@@ -192,7 +192,8 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
+    m_RemovedGameObjects:
+    - {fileID: 5018794445609375772, guid: 5dfb1dc135498354f9085327a3940ad7, type: 3}
     m_AddedGameObjects:
     - targetCorrespondingSourceObject: {fileID: 7262873857064080201, guid: 5dfb1dc135498354f9085327a3940ad7, type: 3}
       insertIndex: -1
@@ -3262,7 +3263,8 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
+    m_RemovedGameObjects:
+    - {fileID: 5018794445609375772, guid: 5dfb1dc135498354f9085327a3940ad7, type: 3}
     m_AddedGameObjects:
     - targetCorrespondingSourceObject: {fileID: 7262873857064080201, guid: 5dfb1dc135498354f9085327a3940ad7, type: 3}
       insertIndex: -1

--- a/Assets/Scripts/GameScene/Event/AbstractEvent/AbstractEvent.cs
+++ b/Assets/Scripts/GameScene/Event/AbstractEvent/AbstractEvent.cs
@@ -98,6 +98,12 @@ public abstract class AbstractEvent : MonoBehaviour
         onTriggerEvent
             .Subscribe(_ =>
             {
+                if (EventStatus == eEventStatus.Triggered)
+                {
+                    return;
+                }
+
+                // 一回しか実行しない
                 EventStatus = eEventStatus.Running;
                 SetIsUnitMove(false);
             })
@@ -141,21 +147,9 @@ public abstract class AbstractEvent : MonoBehaviour
     }
 
     /// <summary>
-    /// イベントのトリガーの条件
-    /// </summary>
-    /// <returns> イベントをトリガーするか </returns>
-    public abstract bool IsTriggerEvent();
-
-    /// <summary>
     /// イベントをトリガーする
     /// </summary>
     public abstract void TriggerEvent();
-
-    /// <summary>
-    /// イベントが終了したか
-    /// </summary>
-    /// <returns> 終了したか </returns>
-    public abstract bool IsFinishEvent();
 
     public virtual void OnFinishEvent()
     {

--- a/Assets/Scripts/GameScene/Event/AbstractEvent/AbstractEvent.cs
+++ b/Assets/Scripts/GameScene/Event/AbstractEvent/AbstractEvent.cs
@@ -22,7 +22,10 @@ public abstract class AbstractEvent : MonoBehaviour
     [Header("このイベントが終了したらStoryLayerを上げるか")]
     [SerializeField] private bool _isUpStoryLayer = false;
 
-    private bool _isTriggerForce = false;
+    protected readonly Subject<Unit> onTriggerEvent = new();
+    protected readonly Subject<Unit> onFinishEvent = new();
+
+    private CompositeDisposable _disposable = new();
 
     /// <summary>
     /// イベントID
@@ -44,7 +47,7 @@ public abstract class AbstractEvent : MonoBehaviour
     /// </summary>
     public void TriggerEventForce()
     {
-        _isTriggerForce = true;
+        onTriggerEvent.OnNext(Unit.Default);
     }
 
     void Start()
@@ -54,6 +57,7 @@ public abstract class AbstractEvent : MonoBehaviour
             Debug.LogError("EventManagerが存在しません。");
             return;
         }
+        Bind();
 
         OnStartEvent();
     }
@@ -63,20 +67,10 @@ public abstract class AbstractEvent : MonoBehaviour
     {
         OnUpdateEvent();
 
-        // イベントが実行中はトリガーしない
-        if (EventStatus != eEventStatus.Running)
+        // イベント実行中
+        if (EventStatus == eEventStatus.Running)
         {
-            if (IsTriggerEvent() || _isTriggerForce)
-            {
-                SetIsUnitMove(false); // Unitの移動を無効にする
-                TriggerEvent();
-                EventStatus = eEventStatus.Running;
-            }
-        }
-
-        if (IsFinishEvent() && EventStatus == eEventStatus.Running)
-        {
-            FinishEvent();
+            TriggerEvent();
         }
     }
 
@@ -92,12 +86,29 @@ public abstract class AbstractEvent : MonoBehaviour
         {
             StoryManager.Instance.CurrentStoryLayer++;
         }
-        _isTriggerForce = false;
         OnFinishEvent();
 
 #if DEBUG_MODE
         Debug.Log($"イベント: {_event} が終了しました");
 #endif
+    }
+
+    private void Bind()
+    {
+        onTriggerEvent
+            .Subscribe(_ =>
+            {
+                EventStatus = eEventStatus.Running;
+                SetIsUnitMove(false);
+            })
+            .AddTo(_disposable);
+
+        onFinishEvent
+            .Subscribe(_ =>
+            {
+                FinishEvent();
+            })
+            .AddTo(_disposable);
     }
 
     /// <summary>
@@ -232,5 +243,10 @@ public abstract class AbstractEvent : MonoBehaviour
 
             return eventData;
         }
+    }
+
+    private void OnDestroy()
+    {
+        _disposable?.Dispose();
     }
 }

--- a/Assets/Scripts/GameScene/Event/ChoiceTextEvent/ChoiceTextEvent.cs
+++ b/Assets/Scripts/GameScene/Event/ChoiceTextEvent/ChoiceTextEvent.cs
@@ -71,12 +71,12 @@ public class ChoiceTextEvent : AbstractEvent
         }
     }
 
-    public override bool IsFinishEvent()
+    private bool IsFinishEvent()
     {
         return _isFinish;
     }
 
-    public override bool IsTriggerEvent()
+    private bool IsTriggerEvent()
     {
         return _isInEvent && Input.GetKeyDown(KeyCode.Z);
     }
@@ -110,6 +110,19 @@ public class ChoiceTextEvent : AbstractEvent
         {
             Destroy(_viewObj);
             _viewObj = null;
+        }
+    }
+
+    public override void OnUpdateEvent()
+    {
+        if (IsTriggerEvent())
+        {
+            onTriggerEvent.OnNext(Unit.Default);
+        }
+
+        if (IsFinishEvent())
+        {
+            onFinishEvent.OnNext(Unit.Default);
         }
     }
 

--- a/Assets/Scripts/GameScene/Event/CollisionTriggerEvent.cs
+++ b/Assets/Scripts/GameScene/Event/CollisionTriggerEvent.cs
@@ -41,6 +41,18 @@ public class CollisionTriggerEvent : AbstractEvent
                 StartCoroutine(CloseImage());
             }
         }
+
+        // トリガー条件チェック
+        if (IsTriggerEvent())
+        {
+            onTriggerEvent.OnNext(Unit.Default);
+        }
+
+        // 終了条件チェック
+        if (IsFinishEvent())
+        {
+            onFinishEvent.OnNext(Unit.Default);
+        }
     }
 
     /// <summary>
@@ -48,7 +60,7 @@ public class CollisionTriggerEvent : AbstractEvent
     /// プレイヤーと衝突した場合にトリガーする
     /// </summary>
     /// <returns>イベントをトリガーするか</returns>
-    public override bool IsTriggerEvent()
+    private bool IsTriggerEvent()
     {
         // EventDataが存在しない場合は作成
         try
@@ -96,7 +108,7 @@ public class CollisionTriggerEvent : AbstractEvent
     /// イベントが終了したか
     /// </summary>
     /// <returns>終了したか</returns>
-    public override bool IsFinishEvent()
+    private bool IsFinishEvent()
     {
         return _isEventFinished;
     }

--- a/Assets/Scripts/GameScene/Event/CreateObjectEvent/CreateObjectEvent.cs
+++ b/Assets/Scripts/GameScene/Event/CreateObjectEvent/CreateObjectEvent.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using R3;
 
 public class CreateObjectEvent : AbstractEvent
 {
@@ -20,12 +21,12 @@ public class CreateObjectEvent : AbstractEvent
         }
     }
 
-    public override bool IsFinishEvent()
+    private bool IsFinishEvent()
     {
         return _createdObj != null;
     }
 
-    public override bool IsTriggerEvent()
+    private bool IsTriggerEvent()
     {
         return _isInEvent && (Input.GetKeyDown(KeyCode.Z) || Input.GetKeyDown(KeyCode.Return));
     }
@@ -33,6 +34,21 @@ public class CreateObjectEvent : AbstractEvent
     public override void TriggerEvent()
     {
         CreateObject();
+    }
+
+    public override void OnUpdateEvent()
+    {
+        // トリガー条件チェック
+        if (IsTriggerEvent())
+        {
+            onTriggerEvent.OnNext(Unit.Default);
+        }
+
+        // 終了条件チェック
+        if (IsFinishEvent())
+        {
+            onFinishEvent.OnNext(Unit.Default);
+        }
     }
 
     private void CreateObject()

--- a/Assets/Scripts/GameScene/Event/DarkEvent/DarkEvent.cs
+++ b/Assets/Scripts/GameScene/Event/DarkEvent/DarkEvent.cs
@@ -1,6 +1,7 @@
 using UnityEngine;
 using UnityEngine.UI;
 using DG.Tweening;
+using R3;
 
 public class DarkEvent : AbstractEvent
 {
@@ -116,14 +117,30 @@ public class DarkEvent : AbstractEvent
         }
     }
 
-    public override bool IsFinishEvent()
+    private bool IsFinishEvent()
     {
         return _hasFinished;
     }
 
-    public override bool IsTriggerEvent()
+    private bool IsTriggerEvent()
     {
         return (_isInEvent && Input.GetKeyDown(KeyCode.Z)) || _isTriggerForce;
+    }
+
+    public override void OnUpdateEvent()
+    {
+        // トリガー条件チェック
+        if (IsTriggerEvent())
+        {
+            _isTriggerForce = false;
+            onTriggerEvent.OnNext(Unit.Default);
+        }
+
+        // 終了条件チェック
+        if (IsFinishEvent())
+        {
+            onFinishEvent.OnNext(Unit.Default);
+        }
     }
 
     void OnTriggerEnter2D(Collider2D collision)

--- a/Assets/Scripts/GameScene/Event/DeleteObjectEvent/DeleteObjectEvent.cs
+++ b/Assets/Scripts/GameScene/Event/DeleteObjectEvent/DeleteObjectEvent.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using R3;
 
 public class DeleteObjectEvent : AbstractEvent
 {
@@ -19,12 +20,12 @@ public class DeleteObjectEvent : AbstractEvent
         }
     }
 
-    public override bool IsFinishEvent()
+    private bool IsFinishEvent()
     {
         return !_obj.activeInHierarchy;
     }
 
-    public override bool IsTriggerEvent()
+    private bool IsTriggerEvent()
     {
         return _isInEvent && (Input.GetKeyDown(KeyCode.Z) || Input.GetKeyDown(KeyCode.Return));
     }
@@ -35,6 +36,21 @@ public class DeleteObjectEvent : AbstractEvent
         {
             _obj.SetActive(false);
             Enabled = false;
+        }
+    }
+
+    public override void OnUpdateEvent()
+    {
+        // トリガー条件チェック
+        if (IsTriggerEvent())
+        {
+            onTriggerEvent.OnNext(Unit.Default);
+        }
+
+        // 終了条件チェック
+        if (IsFinishEvent())
+        {
+            onFinishEvent.OnNext(Unit.Default);
         }
     }
 

--- a/Assets/Scripts/GameScene/Event/EventManager.cs
+++ b/Assets/Scripts/GameScene/Event/EventManager.cs
@@ -10,9 +10,13 @@ public class EventManager : Singleton<EventManager>, ISaveableManager<EventSaveD
 
     void Update()
     {
-        foreach (var eventData in _savedEventDatas.Values)
+        foreach (var ev in _allEventsInScene)
         {
-            UpdateActive(eventData.EventId);
+            if (ev == null)
+            {
+                continue;
+            }
+            UpdateActive(ev.EventId);
         }
     }
 
@@ -164,22 +168,21 @@ public class EventManager : Singleton<EventManager>, ISaveableManager<EventSaveD
     {
         return eventData.Enabled;
     }
-    
+
     /// <summary>
     /// 全てのイベントの初期化をする
     /// </summary>
     private void SetActiveAllEventInScene()
     {
-        foreach (var eventData in _savedEventDatas)
+        foreach (var ev in _allEventsInScene)
         {
-            AbstractEvent ev = GetEventByEventId(eventData.Value.EventId);
+            EventData eventData = ev.EventData;
             if (ev == null)
             {
-                // 別シーンのイベントのとき
                 continue;
             }
 
-            if (!IsActiveByTriggeredOnce(eventData.Value) && !IsActiveByStoryLayer(eventData.Value) && !IsActiveByEventDataEnable(eventData.Value))
+            if (!IsActiveByTriggeredOnce(eventData) && !IsActiveByStoryLayer(eventData) && !IsActiveByEventDataEnable(eventData))
             {
                 ev.gameObject.SetActive(false);
             }
@@ -221,7 +224,6 @@ public class EventManager : Singleton<EventManager>, ISaveableManager<EventSaveD
         {
             if (ev == null)
             {
-                Debug.LogError("AbstractEventをコンポーネントしていません。");
                 continue;
             }
 
@@ -249,5 +251,5 @@ public class EventManager : Singleton<EventManager>, ISaveableManager<EventSaveD
     {
         StoryManager.Instance.CurrentStoryLayer = saveData.CurrentStoryLayer;
         _savedEventDatas = saveData.EventData;
-	}
+    }
 }

--- a/Assets/Scripts/GameScene/Event/GameExitEvent.cs
+++ b/Assets/Scripts/GameScene/Event/GameExitEvent.cs
@@ -56,6 +56,15 @@ public class GameExitEvent : AbstractEvent
                 TriggerEvent();
             }
         }
+
+        if (IsTriggerEvent())
+        {
+            onTriggerEvent.OnNext(Unit.Default);
+        }
+        if (IsFinishEvent())
+        {
+            onFinishEvent.OnNext(Unit.Default);
+        }
     }
 
     /// <summary>
@@ -99,7 +108,7 @@ public class GameExitEvent : AbstractEvent
     /// 手動でキーを押した場合のみトリガー
     /// </summary>
     /// <returns>イベントをトリガーするか</returns>
-    public override bool IsTriggerEvent()
+    private bool IsTriggerEvent()
     {
         // このイベントは手動キー入力でのみトリガーするため、常にfalse
         return false;
@@ -120,7 +129,7 @@ public class GameExitEvent : AbstractEvent
     /// イベントが終了したか
     /// </summary>
     /// <returns>終了したか</returns>
-    public override bool IsFinishEvent()
+    private bool IsFinishEvent()
     {
         return _isEventFinished;
     }

--- a/Assets/Scripts/GameScene/Event/Gimmick/1/Dream/CreateEntranceKeyWithMedicineEvent.cs
+++ b/Assets/Scripts/GameScene/Event/Gimmick/1/Dream/CreateEntranceKeyWithMedicineEvent.cs
@@ -41,6 +41,7 @@ public class CreateEntranceKeyWithMedicineEvent : AbstractEvent
         {
             Debug.Log("必要な薬が揃っていません。");
         }
+        onFinishEvent.OnNext(Unit.Default);
         _hasFinished = true;
     }
 
@@ -50,12 +51,6 @@ public class CreateEntranceKeyWithMedicineEvent : AbstractEvent
         if (IsTriggerEvent())
         {
             onTriggerEvent.OnNext(Unit.Default);
-        }
-
-        // 終了条件チェック
-        if (IsFinishEvent())
-        {
-            onFinishEvent.OnNext(Unit.Default);
         }
     }
 

--- a/Assets/Scripts/GameScene/Event/Gimmick/1/Dream/CreateEntranceKeyWithMedicineEvent.cs
+++ b/Assets/Scripts/GameScene/Event/Gimmick/1/Dream/CreateEntranceKeyWithMedicineEvent.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using R3;
 
 public class CreateEntranceKeyWithMedicineEvent : AbstractEvent
 {
@@ -6,7 +7,7 @@ public class CreateEntranceKeyWithMedicineEvent : AbstractEvent
 
     private bool _hasFinished = false;
 
-    public override bool IsFinishEvent()
+    private bool IsFinishEvent()
     {
         if (EventStatus == eEventStatus.Triggered)
         {
@@ -15,7 +16,7 @@ public class CreateEntranceKeyWithMedicineEvent : AbstractEvent
         return _hasFinished;
     }
 
-    public override bool IsTriggerEvent()
+    private bool IsTriggerEvent()
     {
         return _isPlayerIn && (Input.GetKeyDown(KeyCode.Z) || Input.GetKeyDown(KeyCode.Return));
     }
@@ -41,6 +42,21 @@ public class CreateEntranceKeyWithMedicineEvent : AbstractEvent
             Debug.Log("必要な薬が揃っていません。");
         }
         _hasFinished = true;
+    }
+
+    public override void OnUpdateEvent()
+    {
+        // トリガー条件チェック
+        if (IsTriggerEvent())
+        {
+            onTriggerEvent.OnNext(Unit.Default);
+        }
+
+        // 終了条件チェック
+        if (IsFinishEvent())
+        {
+            onFinishEvent.OnNext(Unit.Default);
+        }
     }
 
     private void OnTriggerEnter2D(Collider2D collision)

--- a/Assets/Scripts/GameScene/Event/Gimmick/1/Dream/Floors2And3StairsPasswordGimmick.cs
+++ b/Assets/Scripts/GameScene/Event/Gimmick/1/Dream/Floors2And3StairsPasswordGimmick.cs
@@ -1,14 +1,15 @@
 using UnityEngine;
+using R3;
 
 public class Floors2And3StairsPasswordGimmick : AbstractEvent
 {
-    [Header("ŠK’i‚Ì•Ç")]
+    [Header("éšæ®µã®å£")]
     [SerializeField] private GameObject _wall;
 
-    [Header("ƒpƒXƒ[ƒh")]
+    [Header("ãƒ‘ã‚¹ãƒ¯ãƒ¼ãƒ‰")]
     [SerializeField] private string _password;
 
-    // Player‚ª“ü—Í‚µ‚½ƒpƒXƒ[ƒh
+    // PlayerãŒå…¥åŠ›ã—ãŸãƒ‘ã‚¹ãƒ¯ãƒ¼ãƒ‰
     private string _userInput;
 
     private bool _isPlayerIn = false;
@@ -18,7 +19,7 @@ public class Floors2And3StairsPasswordGimmick : AbstractEvent
     {
         if (_wall == null)
         {
-            Debug.LogError("•ÇƒIƒuƒWƒFƒNƒg‚ªİ’è‚³‚ê‚Ä‚¢‚Ü‚¹‚ñB");
+            Debug.LogError("å£ã‚ªãƒ–ã‚¸ã‚§ã‚¯ãƒˆãŒè¨­å®šã•ã‚Œã¦ã„ã¾ã›ã‚“ã€‚");
         }
 
         if (!Enabled)
@@ -27,14 +28,14 @@ public class Floors2And3StairsPasswordGimmick : AbstractEvent
         }
     }
 
-    public override bool IsTriggerEvent()
+    private bool IsTriggerEvent()
     {
         return _isPlayerIn && (Input.GetKeyDown(KeyCode.Return) || Input.GetKeyDown(KeyCode.Z));
     }
 
     public override void TriggerEvent()
     {
-        // TODO: UI‚©‚çƒpƒXƒ[ƒh“ü—Í‚ğó‚¯æ‚éˆ—‚É’u‚«Š·‚¦‚é
+        // TODO: UIï¿½ï¿½ï¿½ï¿½pï¿½Xï¿½ï¿½ï¿½[ï¿½hï¿½ï¿½ï¿½Í‚ï¿½ï¿½ó‚¯ï¿½éˆï¿½ï¿½ï¿½É’uï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
         _userInput = "1625";
 
         if (_userInput == _password)
@@ -42,23 +43,38 @@ public class Floors2And3StairsPasswordGimmick : AbstractEvent
             if (_wall != null)
             {
                 _wall.SetActive(false);
-                // ƒCƒxƒ“ƒg‚ğŠ®‘S‚É–³Œø‰»‚·‚é‚½‚ß‚ÉTriggeredƒXƒe[ƒ^ƒX‚Éİ’è
+                // ã‚¤ãƒ™ãƒ³ãƒˆãŒå®Œå…¨ã«ç„¡åŠ¹åŒ–ã•ã‚Œã‚‹ãŸã‚ã«Triggeredã‚¹ãƒ†ãƒ¼ã‚¿ã‚¹ã«è¨­å®š
                 EventStatus = eEventStatus.Triggered;
                 TriggerOnce = true;
-                Debug.Log("‚æ‚¤‚â‚­‚±‚ê‚Å‚PŠK‚É...");
+                Debug.Log("ã‚ˆã†ã‚„ãã“ã“ã§1éšã«...");
             }
         }
         else
         {
-            Debug.Log("ƒpƒXƒ[ƒh‚ªŠÔˆá‚Á‚Ä‚¢‚Ü‚·");
+            Debug.Log("ãƒ‘ã‚¹ãƒ¯ãƒ¼ãƒ‰ãŒé–“é•ã£ã¦ã„ã¾ã™");
         }
 
         _hasFinished = true;
     }
 
-    public override bool IsFinishEvent()
+    private bool IsFinishEvent()
     {
         return _hasFinished;
+    }
+
+    public override void OnUpdateEvent()
+    {
+        // ãƒˆãƒªã‚¬ãƒ¼æ¡ä»¶ãƒã‚§ãƒƒã‚¯
+        if (IsTriggerEvent())
+        {
+            onTriggerEvent.OnNext(Unit.Default);
+        }
+
+        // çµ‚äº†æ¡ä»¶ãƒã‚§ãƒƒã‚¯
+        if (IsFinishEvent())
+        {
+            onFinishEvent.OnNext(Unit.Default);
+        }
     }
 
     private void OnTriggerEnter2D(Collider2D collision)
@@ -68,7 +84,7 @@ public class Floors2And3StairsPasswordGimmick : AbstractEvent
             _isPlayerIn = true;
         }
     }
-    
+
     private void OnTriggerExit2D(Collider2D collision)
     {
         if (collision.CompareTag("Player"))

--- a/Assets/Scripts/GameScene/Event/Gimmick/1/Dream/UseEntranceKeyEvent.cs
+++ b/Assets/Scripts/GameScene/Event/Gimmick/1/Dream/UseEntranceKeyEvent.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using R3;
 
 public class UseEntranceKeyEvent : AbstractEvent
 {
@@ -12,12 +13,12 @@ public class UseEntranceKeyEvent : AbstractEvent
 
     private bool _hasFinished = false;
 
-    public override bool IsFinishEvent()
+    private bool IsFinishEvent()
     {
         return _hasFinished;
     }
 
-    public override bool IsTriggerEvent()
+    private bool IsTriggerEvent()
     {
         return _isInEvent && (Input.GetKeyDown(KeyCode.Z) || Input.GetKeyDown(KeyCode.Return)) && _textEvent.EventStatus != eEventStatus.Running;
     }
@@ -40,6 +41,21 @@ public class UseEntranceKeyEvent : AbstractEvent
         }
 
         _hasFinished = true;
+    }
+
+    public override void OnUpdateEvent()
+    {
+        // トリガー条件チェック
+        if (IsTriggerEvent())
+        {
+            onTriggerEvent.OnNext(Unit.Default);
+        }
+
+        // 終了条件チェック
+        if (IsFinishEvent())
+        {
+            onFinishEvent.OnNext(Unit.Default);
+        }
     }
 
     // MARK: OnTrigger

--- a/Assets/Scripts/GameScene/Event/ItemEvent/ItemEvent.cs
+++ b/Assets/Scripts/GameScene/Event/ItemEvent/ItemEvent.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using R3;
 
 /// <summary>
 /// アイテムに関する処理を行うイベントクラス
@@ -19,7 +20,7 @@ public class ItemEvent : AbstractEvent
     /// イベントのトリガー条件を判定します
     /// </summary>
     /// <returns>トリガー条件を満たす場合は true</returns>
-    public override bool IsTriggerEvent()
+    private bool IsTriggerEvent()
     {
         return _isInEvent && (Input.GetKeyDown(KeyCode.Z) || Input.GetKeyDown(KeyCode.Return));
     }
@@ -53,9 +54,24 @@ public class ItemEvent : AbstractEvent
     /// イベントの終了判定を行います
     /// </summary>
     /// <returns>終了した場合は true</returns>
-    public override bool IsFinishEvent()
+    private bool IsFinishEvent()
     {
         return _hasFinished;
+    }
+
+    public override void OnUpdateEvent()
+    {
+        // トリガー条件チェック
+        if (IsTriggerEvent())
+        {
+            onTriggerEvent.OnNext(Unit.Default);
+        }
+
+        // 終了条件チェック
+        if (IsFinishEvent())
+        {
+            onFinishEvent.OnNext(Unit.Default);
+        }
     }
 
     /// <summary>

--- a/Assets/Scripts/GameScene/Event/MapMoveEvent/MapMoveEvent.cs
+++ b/Assets/Scripts/GameScene/Event/MapMoveEvent/MapMoveEvent.cs
@@ -62,6 +62,13 @@ public class MapMoveEvent : AbstractEvent
     {
         if (IsSceneExist())
         {
+            // 強制的にルートオブジェクトにする
+            if (transform.parent != null)
+            {
+                transform.parent = null;
+            }
+            // 移動したシーン先でオブジェクトがないと終了処理が実行できないため
+            DontDestroyOnLoad(this.gameObject);
             MoveMap();
         }
         else
@@ -84,6 +91,15 @@ public class MapMoveEvent : AbstractEvent
         if (IsFinishEvent())
         {
             onFinishEvent.OnNext(Unit.Default);
+        }
+    }
+
+    public override void OnFinishEvent()
+    {
+        if (this.gameObject != null)
+        {
+            // `DontDestroyOnLoad(this.gameObject);`をしているため
+            Destroy(this.gameObject);
         }
     }
 

--- a/Assets/Scripts/GameScene/Event/MapMoveEvent/MapMoveEvent.cs
+++ b/Assets/Scripts/GameScene/Event/MapMoveEvent/MapMoveEvent.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.SceneManagement;
+using R3;
 
 public class MapMoveEvent : AbstractEvent
 {
@@ -37,7 +38,7 @@ public class MapMoveEvent : AbstractEvent
         }
     }
 
-    public override bool IsTriggerEvent()
+    private bool IsTriggerEvent()
     {
         // ブロックの中にPlayerが入っているとき
         if (_isInEventBlock)
@@ -48,9 +49,12 @@ public class MapMoveEvent : AbstractEvent
         return false;
     }
 
-    public override bool IsFinishEvent()
+    private bool IsFinishEvent()
     {
-        _hasFinished = (EventStatus == eEventStatus.Triggered && _hasFinished == true) ? false : _hasFinished;
+        if (EventStatus == eEventStatus.Triggered)
+        {
+            _hasFinished = false;
+        }
         return _hasFinished;
     }
 
@@ -65,6 +69,22 @@ public class MapMoveEvent : AbstractEvent
             Debug.LogError($"シーンが存在しません: {_sceneName}");
         }
         _hasFinished = true;
+    }
+
+    public override void OnUpdateEvent()
+    {
+        // トリガー条件チェック
+        if (IsTriggerEvent())
+        {
+            _isAutoMove = false;
+            onTriggerEvent.OnNext(Unit.Default);
+        }
+
+        // 終了条件チェック
+        if (IsFinishEvent())
+        {
+            onFinishEvent.OnNext(Unit.Default);
+        }
     }
 
     private void OnTriggerEnter2D(Collider2D other)

--- a/Assets/Scripts/GameScene/Event/PrologueEvent/PrologueEvent.cs
+++ b/Assets/Scripts/GameScene/Event/PrologueEvent/PrologueEvent.cs
@@ -1,5 +1,6 @@
 using UnityEngine;
 using System.Collections.Generic;
+using R3;
 
 /// <summary>
 /// プロローグイベント - 真っ暗な画面にタイプライター効果でテキスト表示
@@ -48,7 +49,7 @@ public class PrologueEvent : AbstractEvent
         }
     }
 
-    public override bool IsTriggerEvent()
+    private bool IsTriggerEvent()
     {
         return (_isInEvent && Input.GetKeyDown(KeyCode.Z)) || _isTriggerForce;
     }
@@ -65,22 +66,26 @@ public class PrologueEvent : AbstractEvent
 
     public override void OnUpdateEvent()
     {
+        // トリガー条件チェック
+        if (IsTriggerEvent())
+        {
+            _isTriggerForce = false;
+            onTriggerEvent.OnNext(Unit.Default);
+        }
+
         // プレゼンターがキー入力を処理するため、ここでは完了チェックのみ
         if (_prologuePresenter != null && _prologuePresenter.IsFinished())
         {
             CleanupPrologueUI();
             _hasFinished = true;
         }
-    }
 
-    public override bool IsFinishEvent()
-    {
+        // 終了条件チェック
         if (_hasFinished)
         {
             _hasFinished = false;
-            return true;
+            onFinishEvent.OnNext(Unit.Default);
         }
-        return false;
     }
 
     private bool CanStartPrologue()

--- a/Assets/Scripts/GameScene/Event/PrologueEvent/PrologueEvent.cs
+++ b/Assets/Scripts/GameScene/Event/PrologueEvent/PrologueEvent.cs
@@ -79,12 +79,6 @@ public class PrologueEvent : AbstractEvent
             CleanupPrologueUI();
             onFinishEvent.OnNext(Unit.Default);
         }
-
-        // 終了条件チェック
-        if (_hasFinished)
-        {
-            onFinishEvent.OnNext(Unit.Default);
-        }
     }
 
     private bool CanStartPrologue()

--- a/Assets/Scripts/GameScene/Event/PrologueEvent/PrologueEvent.cs
+++ b/Assets/Scripts/GameScene/Event/PrologueEvent/PrologueEvent.cs
@@ -77,13 +77,12 @@ public class PrologueEvent : AbstractEvent
         if (_prologuePresenter != null && _prologuePresenter.IsFinished())
         {
             CleanupPrologueUI();
-            _hasFinished = true;
+            onFinishEvent.OnNext(Unit.Default);
         }
 
         // 終了条件チェック
         if (_hasFinished)
         {
-            _hasFinished = false;
             onFinishEvent.OnNext(Unit.Default);
         }
     }

--- a/Assets/Scripts/GameScene/Event/SetDateEvent/SetDateEvent.cs
+++ b/Assets/Scripts/GameScene/Event/SetDateEvent/SetDateEvent.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using R3;
 
 public class SetDateEvent : AbstractEvent
 {
@@ -29,19 +30,34 @@ public class SetDateEvent : AbstractEvent
         _hasFinished = true;
     }
 
-    public override bool IsFinishEvent()
+    private bool IsFinishEvent()
     {
-        if (_hasFinished)
+        if (EventStatus == eEventStatus.Triggered)
         {
             _hasFinished = false;
-            return true;
         }
-        return false;
+        return _hasFinished;
     }
 
-    public override bool IsTriggerEvent()
+    private bool IsTriggerEvent()
     {
         return (_isInEvent && Input.GetKeyDown(KeyCode.Z)) || _isTriggerForce;
+    }
+
+    public override void OnUpdateEvent()
+    {
+        // トリガー条件チェック
+        if (IsTriggerEvent())
+        {
+            _isTriggerForce = false;
+            onTriggerEvent.OnNext(Unit.Default);
+        }
+
+        // 終了条件チェック
+        if (IsFinishEvent())
+        {
+            onFinishEvent.OnNext(Unit.Default);
+        }
     }
 
     void OnTriggerEnter2D(Collider2D collision)

--- a/Assets/Scripts/GameScene/Event/SpawnEnemyEvent/SpawnEnemyEvent.cs
+++ b/Assets/Scripts/GameScene/Event/SpawnEnemyEvent/SpawnEnemyEvent.cs
@@ -1,17 +1,18 @@
 using UnityEngine;
+using R3;
 
 public class SpawnEnemyEvent : AbstractEvent
 {
     [SerializeField] private EnemySpawnManager _enemySpawnManager;
 
-    [Header("ƒXƒ|[ƒ“ˆÊ’u")]
+    [Header("ã‚¹ãƒãƒ¼ãƒ³ä½ç½®")]
     [SerializeField] private Vector2 _position;
 
     private bool _isInEnter;
     private bool _hasFinished = false;
 
     /// <summary>
-    /// “G‚ğƒXƒ|[ƒ“‚³‚¹‚éƒCƒxƒ“ƒg‚ğÀs‚µ‚Ü‚·B
+    /// æ•µã‚’ã‚¹ãƒãƒ¼ãƒ³ã•ã›ã‚‹ã‚¤ãƒ™ãƒ³ãƒˆã‚’å®Ÿè¡Œã—ã¾ã™ã€‚
     /// </summary>
     public override void TriggerEvent()
     {
@@ -20,32 +21,46 @@ public class SpawnEnemyEvent : AbstractEvent
     }
 
     /// <summary>
-    /// ƒCƒxƒ“ƒg‚ğƒgƒŠƒK[‚·‚éğŒ‚ğ–‚½‚µ‚Ä‚¢‚é‚©‚ğ”»’è‚µ‚Ü‚·B
+    /// ã‚¤ãƒ™ãƒ³ãƒˆã‚’ãƒˆãƒªã‚¬ãƒ¼ã™ã‚‹æ¡ä»¶ã‚’æº€ãŸã—ã¦ã„ã‚‹ã‹ã‚’åˆ¤å®šã—ã¾ã™ã€‚
     /// </summary>
-    /// <returns>ğŒ‚ğ–‚½‚µ‚Ä‚¢‚éê‡‚Í trueA‚»‚êˆÈŠO‚Í falseB</returns>
-    public override bool IsTriggerEvent()
+    /// <returns>æ¡ä»¶ã‚’æº€ãŸã—ã¦ã„ã‚‹å ´åˆã¯ trueã€ãã‚Œä»¥å¤–ã¯ falseã€‚</returns>
+    private bool IsTriggerEvent()
+    {
+        return _isInEnter && (Input.GetKeyDown(KeyCode.Z) || Input.GetKey(KeyCode.Return));
+    }
+
+    /// <summary>
+    /// ã‚¤ãƒ™ãƒ³ãƒˆãŒçµ‚äº†ã—ãŸã‹ã©ã†ã‹ã‚’åˆ¤å®šã—ã¾ã™ã€‚
+    /// </summary>
+    /// <returns>çµ‚äº†ã—ã¦ã„ã‚‹å ´åˆã¯ trueã€ãã‚Œä»¥å¤–ã¯ falseã€‚</returns>
+    private bool IsFinishEvent()
     {
         if (EventStatus == eEventStatus.Triggered)
         {
             _hasFinished = false;
         }
-
-        return _isInEnter && (Input.GetKeyDown(KeyCode.Z) || Input.GetKey(KeyCode.Return));
-    }
-
-    /// <summary>
-    /// ƒCƒxƒ“ƒg‚ªI—¹‚µ‚½‚©‚Ç‚¤‚©‚ğ”»’è‚µ‚Ü‚·B
-    /// </summary>
-    /// <returns>I—¹‚µ‚Ä‚¢‚éê‡‚Í trueA‚»‚êˆÈŠO‚Í falseB</returns>
-    public override bool IsFinishEvent()
-    {
         return _hasFinished;
     }
 
+    public override void OnUpdateEvent()
+    {
+        // ãƒˆãƒªã‚¬ãƒ¼æ¡ä»¶ãƒã‚§ãƒƒã‚¯
+        if (IsTriggerEvent())
+        {
+            onTriggerEvent.OnNext(Unit.Default);
+        }
+
+        // çµ‚äº†æ¡ä»¶ãƒã‚§ãƒƒã‚¯
+        if (IsFinishEvent())
+        {
+            onFinishEvent.OnNext(Unit.Default);
+        }
+    }
+
     /// <summary>
-    /// ƒvƒŒƒCƒ„[‚ªƒgƒŠƒK[”ÍˆÍ‚É“ü‚Á‚½Û‚ÉŒÄ‚Ño‚³‚ê‚Ü‚·B
+    /// ãƒ—ãƒ¬ã‚¤ãƒ¤ãƒ¼ãŒãƒˆãƒªã‚¬ãƒ¼ç¯„å›²ã«å…¥ã£ãŸéš›ã«å‘¼ã³å‡ºã•ã‚Œã¾ã™ã€‚
     /// </summary>
-    /// <param name="collision">ƒgƒŠƒK[‚É“ü‚Á‚½ƒIƒuƒWƒFƒNƒg‚ÌƒRƒ‰ƒCƒ_[B</param>
+    /// <param name="collision">ãƒˆãƒªã‚¬ãƒ¼ã«å…¥ã£ãŸã‚ªãƒ–ã‚¸ã‚§ã‚¯ãƒˆã®ã‚³ãƒ©ã‚¤ãƒ€ãƒ¼ã€‚</param>
     private void OnTriggerEnter2D(Collider2D collision)
     {
         if (collision.CompareTag("Player"))

--- a/Assets/Scripts/GameScene/Event/TestEvent.cs
+++ b/Assets/Scripts/GameScene/Event/TestEvent.cs
@@ -7,21 +7,25 @@ public class TestEvent : AbstractEvent
 
     public override void TriggerEvent()
     {
+        Debug.Log("イベントを実行");
     }
 
     public override void OnFinishEvent()
     {
+        Debug.Log("イベントを終了");
     }
 
     public override void OnUpdateEvent()
     {
         if (Input.GetKeyDown(KeyCode.A))
         {
+            // イベントを発生させる
             onTriggerEvent.OnNext(Unit.Default);
         }
 
         if (Input.GetKeyDown(KeyCode.B))
         {
+            // イベントを終了させる
             onFinishEvent.OnNext(Unit.Default);
         }
     }

--- a/Assets/Scripts/GameScene/Event/TestEvent.cs
+++ b/Assets/Scripts/GameScene/Event/TestEvent.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using R3;
 
 public class TestEvent : AbstractEvent
 {
@@ -6,22 +7,32 @@ public class TestEvent : AbstractEvent
 
     public override bool IsTriggerEvent()
     {
-        return Input.GetKey(KeyCode.Space);
+        return false;
     }
 
     public override void TriggerEvent()
     {
-#if DEBUG_MODE
-        Debug.Log($"イベント: {Event} がトリガーされました");
-#endif
+    }
+
+    public override void OnFinishEvent()
+    {
     }
 
     public override bool IsFinishEvent()
     {
-        return Input.GetKeyDown(KeyCode.A);
+        return false;
     }
 
     public override void OnUpdateEvent()
     {
+        if (Input.GetKeyDown(KeyCode.A))
+        {
+            onTriggerEvent.OnNext(Unit.Default);
+        }
+
+        if (Input.GetKeyDown(KeyCode.B))
+        {
+            onFinishEvent.OnNext(Unit.Default);
+        }
     }
 }

--- a/Assets/Scripts/GameScene/Event/TestEvent.cs
+++ b/Assets/Scripts/GameScene/Event/TestEvent.cs
@@ -5,22 +5,12 @@ public class TestEvent : AbstractEvent
 {
     // Start is called once before the first execution of Update after the MonoBehaviour is created
 
-    public override bool IsTriggerEvent()
-    {
-        return false;
-    }
-
     public override void TriggerEvent()
     {
     }
 
     public override void OnFinishEvent()
     {
-    }
-
-    public override bool IsFinishEvent()
-    {
-        return false;
     }
 
     public override void OnUpdateEvent()

--- a/Assets/Scripts/GameScene/Event/Text/TextEvent.cs
+++ b/Assets/Scripts/GameScene/Event/Text/TextEvent.cs
@@ -1,5 +1,6 @@
 using UnityEngine;
 using System.Collections.Generic;
+using R3;
 
 [System.Serializable]
 public class TextLine
@@ -63,7 +64,7 @@ public class TextEvent : AbstractEvent
         if (other.CompareTag("Player")) playerInRange = false;
     }
 
-    public override bool IsTriggerEvent()
+    private bool IsTriggerEvent()
     {
         return playerInRange && Input.GetKeyDown(KeyCode.Z);
     }
@@ -102,7 +103,7 @@ public class TextEvent : AbstractEvent
         DisplayCurrentLine();
     }
 
-    public override bool IsFinishEvent()
+    private bool IsFinishEvent()
     {
         if (EventStatus == eEventStatus.Triggered)
         {
@@ -113,12 +114,25 @@ public class TextEvent : AbstractEvent
 
     public override void OnUpdateEvent()
     {
+        // トリガー条件チェック
+        if (IsTriggerEvent())
+        {
+            onTriggerEvent.OnNext(Unit.Default);
+        }
+
+        // イベント実行中の処理
         if (EventStatus == eEventStatus.Running)
         {
             if (isDisplaying && (Input.GetKeyDown(KeyCode.Z) || Input.GetKeyDown(KeyCode.Return)))
             {
                 NextLine();
             }
+        }
+
+        // 終了条件チェック
+        if (IsFinishEvent())
+        {
+            onFinishEvent.OnNext(Unit.Default);
         }
     }
 

--- a/Assets/Scripts/GameScene/Event/Text/TextEvent.cs
+++ b/Assets/Scripts/GameScene/Event/Text/TextEvent.cs
@@ -98,7 +98,6 @@ public class TextEvent : AbstractEvent
             }
         }
 
-        currentLineIndex = 0;
         isDisplaying = true;
         DisplayCurrentLine();
     }
@@ -127,12 +126,6 @@ public class TextEvent : AbstractEvent
             {
                 NextLine();
             }
-        }
-
-        // 終了条件チェック
-        if (IsFinishEvent())
-        {
-            onFinishEvent.OnNext(Unit.Default);
         }
     }
 
@@ -169,6 +162,8 @@ public class TextEvent : AbstractEvent
         {
             isDisplaying = false;
             ClearText();
+            // 終了処理
+            onFinishEvent.OnNext(Unit.Default);
         }
     }
 

--- a/Assets/Scripts/GameScene/Event/UnitMoveEvent/UnitMoveEvent.cs
+++ b/Assets/Scripts/GameScene/Event/UnitMoveEvent/UnitMoveEvent.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using R3;
 
 public class UnitMoveEvent : AbstractEvent
 {
@@ -47,7 +48,8 @@ public class UnitMoveEvent : AbstractEvent
 
         _defaultPosition = unitObj.transform.position;
     }
-    public override bool IsFinishEvent()
+
+    private bool IsFinishEvent()
     {
         Vector3 position = _unitMove.gameObject.transform.position;
         switch (_direction)
@@ -72,7 +74,7 @@ public class UnitMoveEvent : AbstractEvent
         return false;
     }
 
-    public override bool IsTriggerEvent()
+    private bool IsTriggerEvent()
     {
         return (_isInEvent && Input.GetKeyDown(KeyCode.Z)) || _isTriggerForce;
     }
@@ -98,6 +100,22 @@ public class UnitMoveEvent : AbstractEvent
         if (_speed != 0)
         {
             _unitMove.Speed = _defaultSpeed;
+        }
+    }
+
+    public override void OnUpdateEvent()
+    {
+        // トリガー条件チェック
+        if (IsTriggerEvent())
+        {
+            _isTriggerForce = false;
+            onTriggerEvent.OnNext(Unit.Default);
+        }
+
+        // 終了条件チェック
+        if (IsFinishEvent())
+        {
+            onFinishEvent.OnNext(Unit.Default);
         }
     }
 


### PR DESCRIPTION
<!-- GitHub Copilot コードレビューへの指示: プルリクエストをレビューしてコメントする際には日本語でお願いします。 -->

## 🔗 Issue
<!-- 対応するタスクやNotionのリンクを貼ってください -->
- [イベントのEventStatusの管理にR3を導入する](https://www.notion.so/EventStatus-R3-28381840185380998602c0c9d0daa651?v=1e5818401853806e9cc7000cf67c5727&source=copy_link)
- #185 

## 📚 Description
<!-- 変更内容を簡潔に記述してください（例: 機能追加、バグ修正、リファクタリングなど） -->
- [x] `IsTriggerEvent()`と`IsFinishEvent()`の返り値で判断するのではなく、R3の通知で管理するように修正
    - `AbstractEvent`から`IsTriggerEvent()`と`IsFinishEvent()`の除去
    - Subjectである、`onTriggerEvent`と`onFinishEvent`を実装
    - まだ開発中なので仕様変更はする可能性がある
- [x] 既存のイベントにこの変更を適応
- [x] 今回の修正によりバグったイベントの修正
    - MapMoveEvent
        - `onFinishEvent.OnNext(Unit.Default)`をする前にシーンが変わってしまうため終了処理が実行されない

|`onTriggerEvent`|`onFinishEvent`|
|-----------------|----------------|
|イベントを実行する|イベントを終了する。|

- `TestEvent`で見ると使い方がわかりやすいかも

## 📸 Screenshot / 動作確認結果（必要があれば）
<!-- UI変更がある場合、スクショや画面キャプチャを貼るとレビューが楽になります -->


## 🚧 Not included in this PR
<!-- このPRには含まれていないが、関連しているものや次に対応する予定のもの -->


## 📝 Reviewer checklist & Notes
<!-- 補足情報・レビュワーへの伝達事項・悩んでいることなど -->